### PR TITLE
Add wait for elasticsearch service

### DIFF
--- a/tasks/elasticsearch_activate.yml
+++ b/tasks/elasticsearch_activate.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Wait for Elasticsearch service to become available
+  wait_for:
+    port: 9200
+    delay: 10
+
 - name: Check current Elastic license
   uri:
     url: "http://localhost:9200/_xpack/license" 


### PR DESCRIPTION
The task need to wait for elasticsearch service to come up first. Otherwise, activation will be unsuccessful.