### PR TITLE
change to make task name copy elasticsearch env config

### DIFF
--- a/tasks/elasticsearch_install.yml
+++ b/tasks/elasticsearch_install.yml
@@ -26,7 +26,7 @@
   - name: copy elasticsearch environment config
     template:
       src: elasticsearch.j2
-      dest: /etc/sysconfig/elasticsearch
+      dest: "{{ elasticsearch_env_path }}"
 
   - name: Ensure directory exist
     file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Include OS family specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}.yml"
+    
 - include_tasks: elasticsearch_pre.yml
 - include_tasks: elasticsearch_install.yml
 

--- a/templates/elasticsearch.service.j2
+++ b/templates/elasticsearch.service.j2
@@ -10,7 +10,7 @@ PrivateTmp=true
 Environment=ES_HOME={{ elasticsearch_data_path }}
 Environment=ES_PATH_CONF=/etc/elasticsearch
 Environment=PID_DIR=/var/run/elasticsearch
-EnvironmentFile=-/etc/sysconfig/elasticsearch
+EnvironmentFile=-{{ elasticsearch_env_path }}
 
 WorkingDirectory={{ elasticsearch_data_path }}
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+elasticsearch_env_path: /etc/default/elasticsearch

--- a/vars/Redhat.yml
+++ b/vars/Redhat.yml
@@ -1,0 +1,2 @@
+---
+elasticsearch_env_path: /etc/sysconfig/elasticsearch


### PR DESCRIPTION
change to make task name copy elasticsearch env config for Debian and Radhat